### PR TITLE
[Types] rename gas metering coin to not be vendor-specific

### DIFF
--- a/types/src/utility_coin.rs
+++ b/types/src/utility_coin.rs
@@ -11,8 +11,8 @@ use once_cell::sync::Lazy;
 pub static DIEM_COIN_TYPE: Lazy<TypeTag> = Lazy::new(|| {
     TypeTag::Struct(Box::new(StructTag {
         address: AccountAddress::ONE,
-        module: ident_str!("diem_coin").to_owned(),
-        name: ident_str!("DiemCoin").to_owned(),
+        module: ident_str!("gas_coin").to_owned(), //////// 0L //////// a number of API endpoint (e.g. simulate_gas) will check for the coin resource and are looking for a specific name, so we're changing this to the generic coin name
+        name: ident_str!("GasCoin").to_owned(), //////// 0L ////////
         type_params: vec![],
     }))
 });


### PR DESCRIPTION
The platform has a hard-coded variable for the path of the coin diem_coin::DiemCoin, we need this to be generic, otherwise all the tools attempt to check for DiemCoin for transaction fees.