### PR TITLE
[backup] restore tool will not abort on forked epoch

### DIFF
--- a/storage/backup/backup-cli/src/backup_types/epoch_ending/restore.rs
+++ b/storage/backup/backup-cli/src/backup_types/epoch_ending/restore.rs
@@ -235,7 +235,7 @@ impl PreheatedEpochEndingRestore {
                 if let Err(err) = li.next_epoch_state().ok_or_else(|| {
                     anyhow!("Previous epoch ending LedgerInfo doesn't end an epoch")
                 })?.verify(first_li) {
-                    info!("Verification error, likely due to a rescue mission this epoch: {}", err);
+                    warn!("Verification error, likely due to a rescue mission this epoch: {}", err);
                 }
             }
         }

--- a/storage/backup/backup-cli/src/backup_types/epoch_ending/restore.rs
+++ b/storage/backup/backup-cli/src/backup_types/epoch_ending/restore.rs
@@ -232,11 +232,11 @@ impl PreheatedEpochEndingRestore {
                 .get(&first_li.ledger_info().version())
                 .is_none()
             {
-                li.next_epoch_state()
-                    .ok_or_else(|| {
-                        anyhow!("Previous epoch ending LedgerInfo doesn't end an epoch")
-                    })?
-                    .verify(first_li)?;
+                if let Err(err) = li.next_epoch_state().ok_or_else(|| {
+                    anyhow!("Previous epoch ending LedgerInfo doesn't end an epoch")
+                })?.verify(first_li) {
+                    info!("Verification error, likely due to a rescue mission this epoch: {}", err);
+                }
             }
         }
 


### PR DESCRIPTION
Fixes the restore functionality of the `epoch-archive-mainnet` tool. The diem restore tool assumes a continuously operated chain without any rescue missions. This fix prevents the epoch ending verification from aborting when verifying the epoch in which a rescue mission has happened. When restoring, it simply prints an output message indicating that that epoch had a verification error, likely caused by a rescue mission.   