### PR TITLE
Rename example crates to not collide with real crates

### DIFF
--- a/third_party/move/documentation/examples/diem-framework/crates/crypto-derive/Cargo.toml
+++ b/third_party/move/documentation/examples/diem-framework/crates/crypto-derive/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "diem-crypto-derive"
+name = "diem-crypto-derive-example"
 version = "0.0.3"
 authors = ["Diem Association <opensource@diem.com>"]
 publish = false

--- a/third_party/move/documentation/examples/diem-framework/crates/crypto/Cargo.toml
+++ b/third_party/move/documentation/examples/diem-framework/crates/crypto/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "diem-crypto"
+name = "diem-crypto-example"
 version = "0.0.3"
 authors = ["Diem Association <opensource@diem.com>"]
 publish = false


### PR DESCRIPTION
There are two Rust crates under the documentation subtree (`third_party/move/documentation/examples`) that have the same name as real crates exported by the project (`diem-crypto` and `diem-crypto-derive`). It turns out that cargo, when building a depending project scans the entire tree of directories when looking for a crate. There's no way to tell it "hey this stuff is just examples, don't look here". It further turns out that most of the time cargo happens to find the "real" crates first, and it has a "first found wins" design, so all is well. But sometimes (it seems to depend on the filesystem, the version of git, the wind direction...) it gets the wrong (example code) crate. The result is a bunch of hard to explain compile time errors (example below). This PR renames the example crates so they no longer have the same name as the real ones.

This issue is _not_ present in the current upstream main branch.

Example of the build failures that result:

```
error[E0277]: the `?` operator can only be applied to values that implement `Try`
   --> /home/david/.cargo/git/checkouts/diem-7dee55d666bb1ba0/416d1ca/types/src/transaction/mod.rs:325:35
    |
325 |         let fee_payer_signature = fee_payer_private_key.sign(&message)?;
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the `?` operator cannot be applied to type `diem_crypto::ed25519::Ed25519Signature`
    |
    = help: the trait `Try` is not implemented for `diem_crypto::ed25519::Ed25519Signature`

error[E0277]: the `?` operator can only be applied to values that implement `Try`
   --> /home/david/.cargo/git/checkouts/diem-7dee55d666bb1ba0/416d1ca/types/src/transaction/mod.rs:349:25
    |
349 |         let signature = private_key.sign(&self)?;
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^ the `?` operator cannot be applied to type `diem_crypto::ed25519::Ed25519Signature`
    |
    = help: the trait `Try` is not implemented for `diem_crypto::ed25519::Ed25519Signature`

error[E0308]: mismatched types
   --> /home/david/.cargo/git/checkouts/diem-7dee55d666bb1ba0/416d1ca/types/src/transaction/mod.rs:414:9
    |
413 |     pub fn signing_message(&self) -> Result<Vec<u8>, CryptoMaterialError> {
    |                                      ------------------------------------ expected `Result<Vec<u8>, CryptoMaterialError>` because of return type
414 |         signing_message(self)
    |         ^^^^^^^^^^^^^^^^^^^^^ expected `Result<Vec<u8>, CryptoMaterialError>`, found `Vec<u8>`
    |
    = note: expected enum `Result<Vec<_>, CryptoMaterialError>`
             found struct `Vec<_>`
help: try wrapping the expression in `Ok`
    |
414 |         Ok(signing_message(self))
    |         +++                     +

   Compiling miniz_oxide v0.6.2
   Compiling fs_extra v1.2.0
Some errors have detailed explanations: E0277, E0282, E0308, E0432, E0599.
For more information about an error, try `rustc --explain E0277`.
error: could not compile `diem-types` (lib) due to 24 previous errors
warning: build failed, waiting for other jobs to finish...
error: could not compile `diem-types` (lib) due to 24 previous errors
```