### PR TITLE
Add basic ci

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,7 +31,6 @@ jobs:
           # TODO: check if we need all the packages below -- this list comes from the Libra build setup script
           packages: build-essential lld pkg-config libssl-dev libgmp-dev clang
           version: 1.0 # This is a cache key -- change it when you change the package list above
-        run: rustup toolchain list
       - name: Run cargo build
         run:  cargo build
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - ci-test
-      - add-basic-ci
   pull_request:
     types:
       - opened

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,6 +24,12 @@ jobs:
         with:
           toolchain: stable
       - name: Print installed Rust toolchains
+      - name: Install required non-Rust build tools
+      - uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          # TODO: check if we need all the packages below -- this list comes from the Libra build setup script
+          packages: build-essential lld pkg-config libssl-dev libgmp-dev clang
+          version: 1.0 # This is a cache key -- change it when you change the package list above
         run: rustup toolchain list
       - name: Run cargo build
         run:  cargo build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,30 @@
+name: Check code builds
+
+on:
+  push:
+    branches:
+      - main
+      - ci-test
+      - add-basic-ci
+  pull-request:
+    types:
+      - opened
+    branches:
+      - main
+
+jobs:
+  lint-checks:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Rust Toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+      - name: Print installed Rust toolchains
+        run: rustup toolchain list
+      - name: Run cargo build
+        run:  cargo build
+

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,7 +25,7 @@ jobs:
           toolchain: stable
       - name: Print installed Rust toolchains
       - name: Install required non-Rust build tools
-      - uses: awalsh128/cache-apt-pkgs-action@latest
+        uses: awalsh128/cache-apt-pkgs-action@latest
         with:
           # TODO: check if we need all the packages below -- this list comes from the Libra build setup script
           packages: build-essential lld pkg-config libssl-dev libgmp-dev clang

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,7 +6,7 @@ on:
       - main
       - ci-test
       - add-basic-ci
-  pull-request:
+  pull_request:
     types:
       - opened
     branches:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,6 +24,7 @@ jobs:
         with:
           toolchain: stable
       - name: Print installed Rust toolchains
+        run: rustup toolchain list
       - name: Install required non-Rust build tools
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,14 +9,15 @@ on:
 
 jobs:
   lint-checks:
+    name: Run code checks
     runs-on: ubuntu-latest
-  steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-    - name: Run checks on project
-      uses: dtolnay/rust-toolchain@stable
-      components: clippy, rustfmt
-    - name: Run cargo fmt
-      run:  cargo fmt --all -- --check
-    - name: Run cargo clippy
-      run:  cargo clippy --workspace --tests -- -D warnings
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Rust Toolchain
+        uses: dtolnay/rust-toolchain@stable
+        components: clippy, rustfmt
+      - name: Run cargo fmt
+        run:  cargo fmt --all -- --check
+      - name: Run cargo clippy
+        run:  cargo clippy --workspace --tests -- -D warnings

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,22 @@
+name: Run Lint Checks
+
+on:
+  push:
+    branches:
+      - main
+      - ci-test
+      - add-basic-ci
+
+jobs:
+  lint-checks:
+    runs-on: ubuntu-latest
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Run checks on project
+      uses: dtolnay/rust-toolchain@stable
+      components: clippy, rustfmt
+    - name: Run cargo fmt
+      run:  cargo fmt --all -- --check
+    - name: Run cargo clippy
+      run:  cargo clippy --workspace --tests -- -D warnings

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,7 +16,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Install Rust Toolchain
         uses: dtolnay/rust-toolchain@stable
-        components: clippy, rustfmt
+        with:
+          components: clippy, rustfmt
       - name: Run cargo fmt
         run:  cargo fmt --all -- --check
       - name: Run cargo clippy

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
       - ci-test
-  pull-request:
+  pull_request:
     types:
       - opened
     branches:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,4 +1,4 @@
-name: Run Lint Checks
+name: Code Checks
 
 on:
   push:
@@ -9,16 +9,31 @@ on:
 
 jobs:
   lint-checks:
-    name: Run code checks
+    name: Rust code checks
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install Rust Toolchain
-        uses: dtolnay/rust-toolchain@stable
+      # Why are we installing two Rust toolchain versions below?
+      # answer: the rustfmt project is disfunctional, and chooses
+      # to make many of its useful features only available if you run
+      # a nightly toolchain (even though those features themselves are
+      # many years old now). The recommended workaround is to install
+      # both the toolchain version you want to use, and also the nightly
+      # toolchain, just to be able to run "cargo +nightly fmt" to get the
+      # full, very old set of rustfmt functionality.
+      - name: Install Nightly Rust Toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
-          components: clippy, rustfmt
+          toolchain: nightly
+          components: rustfmt
+      - name: Install Stable Rust Toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          components: clippy
       - name: Run cargo fmt
-        run:  cargo fmt --all -- --check
+        # Note the hacky +nightly below
+        run:  cargo _nightly fmt --all -- --check
       - name: Run cargo clippy
         run:  cargo clippy --workspace --tests -- -D warnings

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -7,6 +7,9 @@ on:
       - ci-test
       - add-basic-ci
 
+env:
+  ENABLE_RUSTFMT: False
+
 jobs:
   lint-checks:
     name: Rust code checks
@@ -32,8 +35,14 @@ jobs:
         with:
           toolchain: stable
           components: clippy
+      - name: Print installed Rust toolchains
+        run: rustup toolchain list
       - name: Run cargo fmt
+        if: env.ENABLE_RUSTFMT == 'True'
         # Note the hacky +nightly below
         run:  cargo +nightly fmt --all -- --check
+      - name: Run cargo fmt
+        if: False == env.ENABLE_RUSTFMT == 'True'
+        run:  echo "cargo fmt skipped due to project code not complying with current format rules"
       - name: Run cargo clippy
         run:  cargo clippy --workspace --tests -- -D warnings

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -5,7 +5,11 @@ on:
     branches:
       - main
       - ci-test
-      - add-basic-ci
+  pull-request:
+    types:
+      - opened
+    branches:
+      - main
 
 env:
   ENABLE_RUSTFMT: False

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -42,7 +42,7 @@ jobs:
         # Note the hacky +nightly below
         run:  cargo +nightly fmt --all -- --check
       - name: Run cargo fmt
-        if: False == env.ENABLE_RUSTFMT == 'True'
+        if: env.ENABLE_RUSTFMT != 'True'
         run:  echo "cargo fmt skipped due to project code not complying with current format rules"
       - name: Run cargo clippy
         run:  cargo clippy --workspace --tests -- -D warnings

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -34,6 +34,6 @@ jobs:
           components: clippy
       - name: Run cargo fmt
         # Note the hacky +nightly below
-        run:  cargo _nightly fmt --all -- --check
+        run:  cargo +nightly fmt --all -- --check
       - name: Run cargo clippy
         run:  cargo clippy --workspace --tests -- -D warnings


### PR DESCRIPTION
Adds CI workflows for both "code checks" (cargo clippy and cargo fmt) and "code builds".
Currently cargo fmt is skipped because the codebase totally doesn't conform to the format rules being checked.
