### PR TITLE
Fix push branch to be the default branch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,7 +3,7 @@ name: Check code builds
 on:
   push:
     branches:
-      - main
+      - release
       - ci-test
   pull_request:
     types: [opened, reopened]

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -3,7 +3,7 @@ name: Code Checks
 on:
   push:
     branches:
-      - main
+      - release
       - ci-test
   pull_request:
     types: [opened, reopened]


### PR DESCRIPTION
This repo doesn't use main as the default branch.