### PR TITLE
Remove specific client header check on CORS enable

### DIFF
--- a/api/src/runtime.rs
+++ b/api/src/runtime.rs
@@ -164,16 +164,8 @@ pub fn attach_poem_to_runtime(
         .as_socket_addr()
         .context("Failed to get socket addr from local addr for Poem webserver")?;
     runtime_handle.spawn(async move {
-        let cors = Cors::new()
-            // To allow browsers to use cookies (for cookie-based sticky
-            // routing in the LB) we must enable this:
-            // https://stackoverflow.com/a/24689738/3846032
-            .allow_credentials(true)
-            .allow_methods(vec![Method::GET, Method::POST])
-            .allow_headers(vec![
-                header::CONTENT_TYPE,
-                header::ACCEPT,
-            ]);
+        // Default CORS regime which allows any origin and any headers
+        let cors = Cors::new();
 
         // Build routes for the API
         let route = Route::new()

--- a/api/src/runtime.rs
+++ b/api/src/runtime.rs
@@ -171,7 +171,6 @@ pub fn attach_poem_to_runtime(
             .allow_credentials(true)
             .allow_methods(vec![Method::GET, Method::POST])
             .allow_headers(vec![
-                header::HeaderName::from_static(X_DIEM_CLIENT),
                 header::CONTENT_TYPE,
                 header::ACCEPT,
             ]);


### PR DESCRIPTION
The api service enables the `Access-Control-Allow-Origin` header on server responses. This allows browser-hosted code such as explorers to interact with the api. However, it turns out that the header is only sent if the client's request included the header `x-diem-client` is sent. Since we want to interoperate with any browser-side http client code, and it can be hard to force a header in that situation, this PR disables said header check. The result is that any browser hosted client code will interoperate with the api server.